### PR TITLE
Implement the iforest method of IsoKernel

### DIFF
--- a/ikpykit/anomaly/_idkd.py
+++ b/ikpykit/anomaly/_idkd.py
@@ -28,7 +28,7 @@ class IDKD(OutlierMixin, BaseEstimator):
     similarity with respect to the reference distribution from which the dataset
     was generated.
 
-    This implementation follows the algorithm described in [1]_.
+    This implementation follows the algorithm of Ting et al. (2022).
 
     Parameters
     ----------
@@ -43,12 +43,12 @@ class IDKD(OutlierMixin, BaseEstimator):
         - If float, then draw `max_samples * X.shape[0]` samples.
 
     method : {"inne", "anne", "auto"}, default="inne"
-        Isolation method to use. The original algorithm described in [1]_ uses "inne".
+        Isolation method to use. The original algorithm of Ting et al. (2022) uses "inne".
 
     contamination : {"auto", float}, default="auto"
         The proportion of outliers in the data set.
 
-        - If "auto", the threshold is determined as in [1]_.
+        - If "auto", the threshold is determined as in Ting et al. (2022).
         - If float, the contamination should be in the range (0, 0.5].
 
         Used to define the threshold on the decision function.
@@ -70,7 +70,7 @@ class IDKD(OutlierMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Kai Ming Ting, Bi-Cun Xu, Washio Takashi, Zhi-Hua Zhou (2022).
+    1. Kai Ming Ting, Bi-Cun Xu, Washio Takashi, Zhi-Hua Zhou (2022).
        "Isolation Distributional Kernel: A new tool for kernel based point and group anomaly detections."
        IEEE Transactions on Knowledge and Data Engineering.
 

--- a/ikpykit/anomaly/_iforest.py
+++ b/ikpykit/anomaly/_iforest.py
@@ -84,12 +84,12 @@ class IForest(OutlierMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Liu, F. T., Ting, K. M., & Zhou, Z. H. (2008, December). "Isolation forest."
-           In 2008 Eighth IEEE International Conference on Data Mining (pp. 413-422). IEEE.
+    1. Liu, F. T., Ting, K. M., & Zhou, Z. H. (2008, December). "Isolation forest."
+       In 2008 Eighth IEEE International Conference on Data Mining (pp. 413-422). IEEE.
 
-    .. [2] Liu, F. T., Ting, K. M., & Zhou, Z. H. (2012). "Isolation-based
-           anomaly detection." ACM Transactions on Knowledge Discovery from
-           Data (TKDD), 6(1), 1-39.
+    2. Liu, F. T., Ting, K. M., & Zhou, Z. H. (2012). "Isolation-based
+       anomaly detection." ACM Transactions on Knowledge Discovery from
+       Data (TKDD), 6(1), 1-39.
 
     Examples
     --------

--- a/ikpykit/anomaly/_inne.py
+++ b/ikpykit/anomaly/_inne.py
@@ -62,9 +62,9 @@ class INNE(OutlierMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] T. R. Bandaragoda, K. Ming Ting, D. Albrecht, F. T. Liu, Y. Zhu, and J. R. Wells.
-           "Isolation-based anomaly detection using nearest-neighbor ensembles." In Computational
-           Intelligence, vol. 34, 2018, pp. 968-998.
+    1. T. R. Bandaragoda, K. Ming Ting, D. Albrecht, F. T. Liu, Y. Zhu, and J. R. Wells.
+       "Isolation-based anomaly detection using nearest-neighbor ensembles." In Computational
+       Intelligence, vol. 34, 2018, pp. 968-998.
 
     Examples
     --------

--- a/ikpykit/cluster/_idkc.py
+++ b/ikpykit/cluster/_idkc.py
@@ -109,7 +109,7 @@ class IDKC(BaseEstimator, ClusterMixin):
 
     References
     ----------
-    .. [1] Ye Zhu, Kai Ming Ting (2023). Kernel-based Clustering via Isolation Distributional Kernel. Information Systems.
+    1. Ye Zhu, Kai Ming Ting (2023). Kernel-based Clustering via Isolation Distributional Kernel. Information Systems.
     """
 
     def __init__(

--- a/ikpykit/cluster/_ikahc.py
+++ b/ikpykit/cluster/_ikahc.py
@@ -74,9 +74,9 @@ class IKAHC(BaseEstimator, ClusterMixin):
 
     References
     ----------
-    .. [1] Xin Han, Ye Zhu, Kai Ming Ting, and Gang Li,
-           "The Impact of Isolation Kernel on Agglomerative Hierarchical Clustering Algorithms",
-           Pattern Recognition, 2023, 139: 109517.
+    1. Xin Han, Ye Zhu, Kai Ming Ting, and Gang Li,
+       "The Impact of Isolation Kernel on Agglomerative Hierarchical Clustering Algorithms",
+       Pattern Recognition, 2023, 139: 109517.
 
     Examples
     --------

--- a/ikpykit/cluster/_pskc.py
+++ b/ikpykit/cluster/_pskc.py
@@ -77,8 +77,8 @@ class PSKC(BaseEstimator, ClusterMixin):
 
     References
     ----------
-    .. [1] Kai Ming Ting, Jonathan R. Wells, Ye Zhu (2023) "Point-set Kernel Clustering".
-    IEEE Transactions on Knowledge and Data Engineering. Vol.35, 5147-5158.
+    1. Kai Ming Ting, Jonathan R. Wells, Ye Zhu (2023) "Point-set Kernel Clustering".
+       IEEE Transactions on Knowledge and Data Engineering. Vol.35, 5147-5158.
     """
 
     def __init__(

--- a/ikpykit/graph/_ikgod.py
+++ b/ikpykit/graph/_ikgod.py
@@ -70,7 +70,7 @@ class IKGOD(BaseEstimator):
 
     References
     ----------
-    .. [1] Zhong Zhuang, Kai Ming Ting, Guansong Pang, Shuaibin Song (2023).
+    1. Zhong Zhuang, Kai Ming Ting, Guansong Pang, Shuaibin Song (2023).
        Subgraph Centralization: A Necessary Step for Graph Anomaly Detection.
        Proceedings of The SIAM Conference on Data Mining.
 

--- a/ikpykit/graph/_isographkernel.py
+++ b/ikpykit/graph/_isographkernel.py
@@ -53,8 +53,8 @@ class IsoGraphKernel(BaseEstimator):
 
     References
     ----------
-    .. [1] Bi-Cun Xu, Kai Ming Ting and Yuan Jiang. 2021. "Isolation Graph Kernel".
-    In Proceedings of The Thirty-Fifth AAAI Conference on Artificial Intelligence. 10487-10495.
+    1. Bi-Cun Xu, Kai Ming Ting and Yuan Jiang. 2021. "Isolation Graph Kernel".
+       In Proceedings of The Thirty-Fifth AAAI Conference on Artificial Intelligence. 10487-10495.
 
     Examples
     --------

--- a/ikpykit/group/anomaly/_ikgad.py
+++ b/ikpykit/group/anomaly/_ikgad.py
@@ -70,7 +70,7 @@ class IKGAD(OutlierMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Kai Ming Ting, Bi-Cun Xu, Washio Takashi, Zhi-Hua Zhou (2022).
+    1. Kai Ming Ting, Bi-Cun Xu, Washio Takashi, Zhi-Hua Zhou (2022).
        Isolation Distributional Kernel: A new tool for kernel based point and group anomaly detections.
        IEEE Transactions on Knowledge and Data Engineering.
 

--- a/ikpykit/kernel/_ik_anne.py
+++ b/ikpykit/kernel/_ik_anne.py
@@ -62,9 +62,9 @@ class IK_ANNE(TransformerMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
-    "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
-    In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
+    1. Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
+       "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
+       In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
     """
 
     def __init__(self, n_estimators=100, max_samples=256, random_state=None):

--- a/ikpykit/kernel/_ik_iforest.py
+++ b/ikpykit/kernel/_ik_iforest.py
@@ -9,10 +9,13 @@ work. If not, see <https://creativecommons.org/licenses/by-nc-nd/4.0/>.
 """
 
 import numpy as np
+from scipy import sparse
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.tree import ExtraTreeRegressor
+from sklearn.utils import check_array
+from sklearn.utils.validation import check_is_fitted, check_random_state
 
 MAX_INT = np.iinfo(np.int32).max
-MIN_FLOAT = np.finfo(float).eps
 
 
 class IK_IForest(TransformerMixin, BaseEstimator):
@@ -24,25 +27,21 @@ class IK_IForest(TransformerMixin, BaseEstimator):
     the characteristics of the local data distribution. It has been shown promising
     performance on density and distance-based classification and clustering problems.
 
-    This version uses iforest to split the data space and calculate Isolation
-    kernel Similarity. Based on this implementation, the feature
-    in the Isolation kernel space is the index of the cell in Voronoi diagrams. Each
-    point is represented as a binary vector such that only the cell the point falling
-    into is 1.
+    This version splits the data space with isolation trees: each tree draws
+    `max_samples` points and cuts them apart with axis-parallel splits at random
+    thresholds, so the cells are boxes rather than the Voronoi cells of `anne` or
+    the hyperspheres of `inne`. The feature in the Isolation kernel space is the
+    index of the leaf a point falls into. Each point is represented as a binary
+    vector such that only the cell the point falls into is 1.
 
     Parameters
     ----------
 
-    n_estimators : int
+    n_estimators : int, default=100
         The number of base estimators in the ensemble.
 
-
-    max_samples : int
+    max_samples : int, default=256
         The number of samples to draw from X to train each base estimator.
-
-            - If int, then draw `max_samples` samples.
-            - If float, then draw `max_samples` * X.shape[0]` samples.
-            - If "auto", then `max_samples=min(8, n_samples)`.
 
     random_state : int, RandomState instance or None, default=None
         Controls the pseudo-randomness of the selection of the feature
@@ -51,6 +50,23 @@ class IK_IForest(TransformerMixin, BaseEstimator):
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.
 
+    Attributes
+    ----------
+    max_samples_ : int
+        The number of samples actually drawn, capped at the size of X.
+
+    trees_ : list of ExtraTreeRegressor
+        The isolation trees, one per estimator.
+
+    leaf_indices_ : list of ndarray
+        For each tree, a lookup from the tree's own node ids to a dense cell
+        index. A tree grown on `max_samples_` points has at most that many
+        leaves, since every leaf holds at least one of them, so the cell index
+        always fits the same block width the other methods use.
+
+    is_fitted_ : bool
+        Whether the estimator has been fitted.
+
     References
     ----------
     .. [1] Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
@@ -58,5 +74,98 @@ class IK_IForest(TransformerMixin, BaseEstimator):
     In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, n_estimators=100, max_samples=256, random_state=None):
+        self.n_estimators = n_estimators
+        self.max_samples = max_samples
+        self.random_state = random_state
+
+    def fit(self, X, y=None):
+        """Fit the model on data X.
+
+        Parameters
+        ----------
+        X : np.array of shape (n_samples, n_features)
+            The input instances.
+        y : None
+            Ignored. Present for API consistency.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        X = check_array(X)
+        n_samples = X.shape[0]
+        self.max_samples_ = min(self.max_samples, n_samples)
+        random_state = check_random_state(self.random_state)
+        self._seeds = random_state.randint(MAX_INT, size=self.n_estimators)
+
+        # The height an isolation tree is grown to. Beyond this the tree can
+        # only separate points that are already rare, which is why the standard
+        # isolation forest stops here as well.
+        max_depth = int(np.ceil(np.log2(max(self.max_samples_, 2))))
+
+        self.trees_ = []
+        self.leaf_indices_ = []
+        for i in range(self.n_estimators):
+            rnd = check_random_state(self._seeds[i])
+            subsample = rnd.choice(n_samples, self.max_samples_, replace=False)
+            tree = ExtraTreeRegressor(
+                max_features=1,
+                splitter="random",
+                max_depth=max_depth,
+                random_state=rnd.randint(MAX_INT),
+            )
+            # The target is noise: an isolation tree splits at random and never
+            # consults it, but the regressor needs one to fit against.
+            tree.fit(X[subsample], rnd.uniform(size=self.max_samples_))
+            self.trees_.append(tree)
+            self.leaf_indices_.append(self._dense_leaf_index(tree))
+
+        self.is_fitted_ = True
+        return self
+
+    @staticmethod
+    def _dense_leaf_index(tree):
+        """Map a tree's leaf node ids onto a contiguous range starting at 0.
+
+        The ids the tree assigns are positions in its node array, so they run
+        past the number of leaves and cannot be used as feature columns.
+        """
+        inner = tree.tree_
+        lookup = np.zeros(inner.node_count, dtype=np.int32)
+        leaves = np.flatnonzero(inner.children_left == -1)
+        lookup[leaves] = np.arange(len(leaves), dtype=np.int32)
+        return lookup
+
+    def transform(self, X):
+        """Compute the isolation kernel feature of X.
+
+        Parameters
+        ----------
+        X: array-like of shape (n_instances, n_features)
+            The input instances.
+
+        Returns
+        -------
+        sparse matrix: The finite binary features based on the kernel feature map.
+            The features are organized as a n_instances by (n_estimators * max_samples_) matrix.
+        """
+        check_is_fitted(self, "is_fitted_")
+        X = check_array(X)
+        n_samples = X.shape[0]
+        n_features = self.n_estimators * self.max_samples_
+
+        rows = np.tile(np.arange(n_samples), self.n_estimators)
+        cols = np.empty(n_samples * self.n_estimators, dtype=np.int32)
+        data = np.ones(n_samples * self.n_estimators, dtype=np.float64)
+
+        for est_idx, (tree, leaf_index) in enumerate(
+            zip(self.trees_, self.leaf_indices_, strict=True)
+        ):
+            cells = leaf_index[tree.apply(X)]
+            start_idx = est_idx * n_samples
+            end_idx = (est_idx + 1) * n_samples
+            cols[start_idx:end_idx] = cells + (est_idx * self.max_samples_)
+
+        return sparse.csr_matrix((data, (rows, cols)), shape=(n_samples, n_features))

--- a/ikpykit/kernel/_ik_iforest.py
+++ b/ikpykit/kernel/_ik_iforest.py
@@ -69,9 +69,9 @@ class IK_IForest(TransformerMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
-    "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
-    In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
+    .. [1] Kai Ming Ting, Yue Zhu, Zhi-Hua Zhou (2018).
+    "Isolation Kernel and Its Effect on SVM".
+    Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2329-2337.
     """
 
     def __init__(self, n_estimators=100, max_samples=256, random_state=None):

--- a/ikpykit/kernel/_ik_iforest.py
+++ b/ikpykit/kernel/_ik_iforest.py
@@ -69,9 +69,9 @@ class IK_IForest(TransformerMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Kai Ming Ting, Yue Zhu, Zhi-Hua Zhou (2018).
-    "Isolation Kernel and Its Effect on SVM".
-    Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2329-2337.
+    1. Kai Ming Ting, Yue Zhu, Zhi-Hua Zhou (2018).
+       "Isolation Kernel and Its Effect on SVM".
+       Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2329-2337.
     """
 
     def __init__(self, n_estimators=100, max_samples=256, random_state=None):

--- a/ikpykit/kernel/_ik_inne.py
+++ b/ikpykit/kernel/_ik_inne.py
@@ -29,11 +29,14 @@ class IK_INNE(TransformerMixin, BaseEstimator):
     the characteristics of the local data distribution. It has been shown promising
     performance on density and distance-based classification and clustering problems.
 
-    This version uses iforest to split the data space and calculate Isolation
-    kernel Similarity. Based on this implementation, the feature
-    in the Isolation kernel space is the index of the cell in Voronoi diagrams. Each
-    point is represented as a binary vector such that only the cell the point falling
-    into is 1.
+    This version splits the data space with hyperspheres: each estimator draws
+    `max_samples` points and puts a ball around every one of them, reaching out
+    to that point's nearest neighbour among the draw. The cells are therefore
+    balls, where `anne` has Voronoi cells and `iforest` has axis-parallel boxes.
+    The feature in the Isolation kernel space is the index of the ball a point
+    falls into, so each point is represented as a binary vector such that only
+    the cell the point falling into is 1. A point outside every ball falls into
+    no cell and is represented by zeros.
 
     Parameters
     ----------
@@ -50,9 +53,13 @@ class IK_INNE(TransformerMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
-    "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
-    In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
+    1. Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
+       "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
+       In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
+
+    2. T. R. Bandaragoda, K. Ming Ting, D. Albrecht, F. T. Liu, Y. Zhu, and J. R. Wells.
+       "Isolation-based anomaly detection using nearest-neighbor ensembles." In Computational
+       Intelligence, vol. 34, 2018, pp. 968-998.
     """
 
     def __init__(self, n_estimators, max_samples, random_state=None):

--- a/ikpykit/kernel/_isodiskernel.py
+++ b/ikpykit/kernel/_isodiskernel.py
@@ -50,10 +50,10 @@ class IsoDisKernel(BaseEstimator, TransformerMixin):
 
     References
     ----------
-    .. [1] Kai Ming Ting, Bi-Cun Xu, Takashi Washio, and Zhi-Hua Zhou. 2020.
-    "Isolation Distributional Kernel: A New Tool for Kernel based Anomaly Detection".
-    In Proceedings of the 26th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining (KDD '20).
-    Association for Computing Machinery, New York, NY, USA, 198-206.
+    1. Kai Ming Ting, Bi-Cun Xu, Takashi Washio, and Zhi-Hua Zhou. 2020.
+       "Isolation Distributional Kernel: A New Tool for Kernel based Anomaly Detection".
+       In Proceedings of the 26th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining (KDD '20).
+       Association for Computing Machinery, New York, NY, USA, 198-206.
 
     Examples
     --------

--- a/ikpykit/kernel/_isokernel.py
+++ b/ikpykit/kernel/_isokernel.py
@@ -36,7 +36,14 @@ class IsoKernel(TransformerMixin, BaseEstimator):
     Parameters
     ----------
     method : str, default="anne"
-        The method to compute the isolation kernel feature. The available methods are: `anne`, `inne`, and `iforest`.
+        How the data space is partitioned to compute the isolation kernel
+        feature. The three differ only in the shape of the cells they produce.
+
+            - `anne`: Voronoi cells around sampled points (Qin et al., 2019).
+            - `inne`: hyperspheres reaching each sampled point's nearest
+              neighbour (Qin et al., 2019).
+            - `iforest`: axis-parallel boxes cut by isolation trees
+              (Ting et al., 2018).
 
     n_estimators : int, default=200
         The number of base estimators in the ensemble.
@@ -61,6 +68,10 @@ class IsoKernel(TransformerMixin, BaseEstimator):
     .. [1] Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
     "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
     In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
+
+    .. [2] Kai Ming Ting, Yue Zhu, Zhi-Hua Zhou (2018).
+    "Isolation Kernel and Its Effect on SVM".
+    Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2329-2337.
 
     Examples
     --------

--- a/ikpykit/kernel/_isokernel.py
+++ b/ikpykit/kernel/_isokernel.py
@@ -41,7 +41,7 @@ class IsoKernel(TransformerMixin, BaseEstimator):
 
             - `anne`: Voronoi cells around sampled points (Qin et al., 2019).
             - `inne`: hyperspheres reaching each sampled point's nearest
-              neighbour (Qin et al., 2019).
+              neighbour (Bandaragoda et al., 2018; Qin et al., 2019).
             - `iforest`: axis-parallel boxes cut by isolation trees
               (Ting et al., 2018).
 
@@ -65,13 +65,17 @@ class IsoKernel(TransformerMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
-    "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
-    In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
+    1. Qin, X., Ting, K.M., Zhu, Y. and Lee, V.C.
+       "Nearest-neighbour-induced isolation similarity and its impact on density-based clustering".
+       In Proceedings of the AAAI Conference on Artificial Intelligence, Vol. 33, 2019, July, pp. 4755-4762
 
-    .. [2] Kai Ming Ting, Yue Zhu, Zhi-Hua Zhou (2018).
-    "Isolation Kernel and Its Effect on SVM".
-    Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2329-2337.
+    2. Kai Ming Ting, Yue Zhu, Zhi-Hua Zhou (2018).
+       "Isolation Kernel and Its Effect on SVM".
+       Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2329-2337.
+
+    3. T. R. Bandaragoda, K. Ming Ting, D. Albrecht, F. T. Liu, Y. Zhu, and J. R. Wells.
+       "Isolation-based anomaly detection using nearest-neighbor ensembles." In Computational
+       Intelligence, vol. 34, 2018, pp. 968-998.
 
     Examples
     --------

--- a/ikpykit/kernel/tests/test_isokernel.py
+++ b/ikpykit/kernel/tests/test_isokernel.py
@@ -4,12 +4,13 @@ Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file.
 """
 
+import numpy as np
 import pytest
 from sklearn.datasets import load_iris
 
 from ikpykit import IsoKernel
 
-method = ["inne", "anne"]
+method = ["inne", "anne", "iforest"]
 
 
 @pytest.fixture
@@ -42,3 +43,66 @@ def test_IsoKernel_transform(data, method):
     ik.fit(X)
     transformed_X = ik.transform(X)
     assert transformed_X.shape == (X.shape[0], ik.n_estimators * max_samples)
+
+
+@pytest.mark.parametrize("method", method)
+def test_IsoKernel_transform_is_one_hot_per_estimator(data, method):
+    """Every estimator must place a sample in exactly one of its cells.
+
+    `inne` is excluded from the lower bound: a point outside every hypersphere
+    falls in no cell, which is that method's way of saying "unlike anything seen".
+    """
+    X = data[0]
+    max_samples, n_estimators = 8, 20
+    ik = IsoKernel(
+        method=method,
+        n_estimators=n_estimators,
+        max_samples=max_samples,
+        random_state=0,
+    ).fit(X)
+    blocks = ik.transform(X).toarray().reshape(X.shape[0], n_estimators, max_samples)
+    per_block = blocks.sum(axis=2)
+
+    assert per_block.max() == 1
+    if method != "inne":
+        assert per_block.min() == 1
+
+
+@pytest.mark.parametrize("method", method)
+def test_IsoKernel_similarity_is_higher_in_sparse_regions(method):
+    """The property the kernel exists for: isolation is easier where it is empty.
+
+    Two neighbours out on their own should score as more similar than two
+    neighbours inside a crowd, even though the sparse pair is further apart.
+    """
+    rng = np.random.RandomState(0)
+    crowd = rng.randn(200, 2) * 0.3
+    outliers = np.array([[6.0, 6.0], [6.4, 6.4]])
+    X = np.vstack([crowd, outliers])
+
+    similarity = (
+        IsoKernel(method=method, n_estimators=300, max_samples=16, random_state=0)
+        .fit(X)
+        .similarity(X)
+    )
+
+    assert similarity[-1, -2] > similarity[0, 1]
+
+
+@pytest.mark.parametrize("method", method)
+def test_IsoKernel_is_reproducible(data, method):
+    X = data[0]
+
+    def embed(random_state):
+        ik = IsoKernel(
+            method=method, n_estimators=20, max_samples=8, random_state=random_state
+        )
+        return ik.fit(X).transform(X)
+
+    assert (embed(42) != embed(42)).nnz == 0
+    assert (embed(42) != embed(7)).nnz > 0
+
+
+def test_IsoKernel_rejects_unknown_method(data):
+    with pytest.raises(ValueError, match="is not supported"):
+        IsoKernel(method="nope").fit(data[0])

--- a/ikpykit/stream/changedetect/_icid.py
+++ b/ikpykit/stream/changedetect/_icid.py
@@ -81,9 +81,9 @@ class ICID(BaseEstimator):
 
     References
     ----------
-    .. [1] Y. Cao, Y. Zhu, K. M. Ting, F. D. Salim, H. X. Li, L. Yang, G. Li (2024).
-           Detecting change intervals with isolation distributional kernel.
-            Journal of Artificial Intelligence Research, 79:273-306.
+    1. Y. Cao, Y. Zhu, K. M. Ting, F. D. Salim, H. X. Li, L. Yang, G. Li (2024).
+       Detecting change intervals with isolation distributional kernel.
+       Journal of Artificial Intelligence Research, 79:273-306.
 
     Examples
     --------

--- a/ikpykit/stream/cluster/_streakhc.py
+++ b/ikpykit/stream/cluster/_streakhc.py
@@ -85,9 +85,9 @@ class STREAMKHC(BaseEstimator, ClusterMixin):
 
     References
     ----------
-    .. [1] Xin Han, Ye Zhu, Kai Ming Ting, De-Chuan Zhan, Gang Li (2022)
-           Streaming Hierarchical Clustering Based on Point-Set Kernel.
-           Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining.
+    1. Xin Han, Ye Zhu, Kai Ming Ting, De-Chuan Zhan, Gang Li (2022)
+       Streaming Hierarchical Clustering Based on Point-Set Kernel.
+       Proceedings of The ACM SIGKDD Conference on Knowledge Discovery and Data Mining.
     """
 
     def __init__(

--- a/ikpykit/timeseries/anomaly/_iktod.py
+++ b/ikpykit/timeseries/anomaly/_iktod.py
@@ -78,9 +78,9 @@ class IKTOD(OutlierMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Ting, K.M., Liu, Z., Zhang, H., Zhu, Y. (2022). A New Distributional
-           Treatment for Time Series and An Anomaly Detection Investigation.
-           Proceedings of The Very Large Data Bases (VLDB) Conference.
+    1. Ting, K.M., Liu, Z., Zhang, H., Zhu, Y. (2022). A New Distributional
+       Treatment for Time Series and An Anomaly Detection Investigation.
+       Proceedings of The Very Large Data Bases (VLDB) Conference.
 
     Examples
     --------

--- a/ikpykit/trajectory/anomaly/_ikat.py
+++ b/ikpykit/trajectory/anomaly/_ikat.py
@@ -61,7 +61,7 @@ class IKAT(OutlierMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Wang, Y., Wang, Z., Ting, K. M., & Shang, Y. (2024).
+    1. Wang, Y., Wang, Z., Ting, K. M., & Shang, Y. (2024).
        A Principled Distributional Approach to Trajectory Similarity Measurement and
        its Application to Anomaly Detection. Journal of Artificial Intelligence Research, 79, 865-893.
 

--- a/ikpykit/trajectory/cluster/_tidkc.py
+++ b/ikpykit/trajectory/cluster/_tidkc.py
@@ -80,8 +80,8 @@ class TIDKC(BaseEstimator, ClusterMixin):
 
     References
     ----------
-    .. [1] Z. J. Wang, Y. Zhu and K. M. Ting, "Distribution-Based Trajectory Clustering,"
-           2023 IEEE International Conference on Data Mining (ICDM).
+    1. Z. J. Wang, Y. Zhu and K. M. Ting, "Distribution-Based Trajectory Clustering,"
+       2023 IEEE International Conference on Data Mining (ICDM).
 
     Examples
     --------

--- a/ikpykit/trajectory/dataloader/_sheepdogs.py
+++ b/ikpykit/trajectory/dataloader/_sheepdogs.py
@@ -27,9 +27,9 @@ class SheepDogs(FileDataset):
 
     References
     ----------
-    .. [1] Movebank: https://www.movebank.org/cms/movebank-main
+    1. Movebank: https://www.movebank.org/cms/movebank-main
 
-    .. [2] Wang, Y., Wang, Z., Ting, K. M., & Shang, Y. (2024).
+    2. Wang, Y., Wang, Z., Ting, K. M., & Shang, Y. (2024).
        A Principled Distributional Approach to Trajectory Similarity Measurement and
        its Application to Anomaly Detection. Journal of Artificial Intelligence Research, 79, 865-893.
 


### PR DESCRIPTION
## The bug

`IsoKernel` documents `iforest` alongside `anne` and `inne`, and [dispatches to it](ikpykit/kernel/_isokernel.py#L132) — but `IK_IForest` was a docstring with `def __init__(self): pass` underneath. Following the documentation crashed:

```python
>>> IsoKernel(method="iforest").fit(X)
TypeError: IK_IForest.__init__() takes 1 positional argument but 4 were given
```

## The implementation

Each estimator draws `max_samples` points and grows an isolation tree over them — one feature at a time, random threshold, to the height a standard isolation forest stops at (`ceil(log2(ψ))`). A point's feature is the leaf it lands in, so the cells are **axis-parallel boxes**, where `anne` has Voronoi cells and `inne` has hyperspheres.

Built from `ExtraTreeRegressor` directly rather than `IsolationForest`, which would also fit an anomaly scorer (`offset_`) over all of X that this has no use for. The structure mirrors `_ik_anne.py`: per-estimator seeds, per-estimator subsample.

### One thing worth knowing

A tree numbers its leaves by their position in its node array, so the ids run past the number of leaves and can't be used as feature columns:

```
tree 0: node_count=15  distinct leaves=8   max leaf id=14
tree 2: node_count=19  distinct leaves=10  max leaf id=18
```

They're mapped onto a contiguous range. That range always fits the block width the other two methods use — **a tree grown on ψ points has at most ψ leaves, because every leaf holds at least one of them** — so `transform` keeps the existing `(n_samples, n_estimators × max_samples)` shape contract that `test_IsoKernel_transform` already asserts. Verified empirically across ψ from 4 to 256; leaf counts topped out at ψ every time.

## Tests

`method` in the test module was `["inne", "anne"]` — iforest was excluded because it didn't work. It's now included, so the three existing tests cover it, plus three new cases asserting what the kernel is supposed to guarantee:

| Test | Checks |
| --- | --- |
| `..._is_one_hot_per_estimator` | Exactly one cell per estimator. `inne` is excluded from the lower bound — a point outside every hypersphere legitimately falls in no cell |
| `..._is_reproducible` | Same `random_state` → identical embedding; different → different |
| `..._similarity_is_higher_in_sparse_regions` | **The property the kernel exists for**: two neighbours alone in a sparse region score as more similar than two neighbours inside a crowd |

On that last fixture:

| method | sparse pair | dense pair |
| --- | --- | --- |
| `anne` | 0.977 | 0.110 |
| `inne` | 0.153 | 0.003 |
| `iforest` | **0.970** | **0.227** |

Also added a case for the unknown-method `ValueError`, which had no coverage.

## Scope

`IDKD`, `IDKC`, `IKAHC` and `ICID` each whitelist only the methods their papers specify — `IKAHC` rejects anything outside `["inne", "anne"]` explicitly. Widening those changes published algorithm behaviour and is a separate decision, so they're untouched.

## Verification

`ikpykit/kernel/tests/` — 25 passed locally. The full suite is left to CI on this PR; local runs are slow here. All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)